### PR TITLE
Force TLS Version - had to move the http register inside of the weburlwatch proc to get it to work for some reason

### DIFF
--- a/durby.tcl
+++ b/durby.tcl
@@ -266,7 +266,6 @@ variable durbyCollectTitles  1
 # <--- end of config; script begins
 
 package require http
-if {![catch {package require tls}]} { ::http::register https 443 ::tls::socket }
 if {([lsearch [info commands] zlib] == -1) && ([catch {package require zlib} error] !=0)} {
   if {([catch {package require Trf} error] == 0) || ([lsearch [info commands] zip] != -1)} {
     putlog "durby: Found trf package. Fast lane activated!"
@@ -292,6 +291,7 @@ bind pub - !durby webby
 bind pubm - {*://*} weburlwatch
 
 proc weburlwatch {nick host user chan text} {
+  if {![catch {package require tls}]} { http::register https 443 [list ::tls::socket -tls1 1 -ssl2 0 -ssl3 0] }
   # watch for web urls in channel
   variable weburlwatch
   set result ""


### PR DESCRIPTION
Force TLS Version - had to move the http register inside of the weburlwatch proc to get it to work for some reason
